### PR TITLE
Issue with an overload of the G8Tesseract class constructor.

### DIFF
--- a/Tesseract.iOS/TesseractApi.cs
+++ b/Tesseract.iOS/TesseractApi.cs
@@ -53,6 +53,37 @@ namespace Tesseract.iOS
             return Initialized;
         }
 
+        public async Task<bool> Init(string language, string absoluteDataPath, OcrEngineMode? mode = null)
+        {
+            try
+            {
+                // Just some random configDictionary, so that it is not null
+                NSMutableDictionary configDictionary = new NSMutableDictionary();
+                configDictionary.SetValueForKey(new Foundation.NSString("kG8ParamTesseditCharWhitelist"), new Foundation.NSString("123456789"));
+                configDictionary.SetValueForKey(new Foundation.NSString("kG8ParamLoadSystemDawg"), new Foundation.NSString("F"));
+                configDictionary.SetValueForKey(new Foundation.NSString("kG8ParamLoadFreqDawg"), new Foundation.NSString("F"));
+
+                // Same here
+                NSObject[] configFileNames = { };
+
+                // Or any other dir containg a tessdata dir.
+                var resourceDir = "/Volumes/MacintoshHD/Users/mvassilev/temp/Resources/";
+
+                // The overload of G8Tesseract constructor with absoluteDataDir
+                _api = new G8Tesseract(language, configDictionary, configFileNames, resourceDir, G8OCREngineMode.TesseractCubeCombined, true) { Delegate = _progressHandler };
+                //_api = new G8Tesseract(language) { Delegate = _progressHandler };
+                _api.Init();
+                if (mode.HasValue)
+                    SetOcrEngineMode(mode.Value);
+                Initialized = true;
+            }
+            catch (Exception e)
+            {
+                Initialized = false;
+            }
+            return Initialized;
+        }
+
         public void SetVariable (string key, string value)
         {
             CheckIfInitialized ();

--- a/Tesseract/ITesseractApi.cs
+++ b/Tesseract/ITesseractApi.cs
@@ -16,6 +16,10 @@ namespace Tesseract
         Task<bool> Init (string lang, OcrEngineMode? mode = null);
 
         /// <summary>
+        /// Initialise Tesseract OCR with a custom tessdata dir. This method should be called before using Tesseract.
+        /// </summary>
+        Task<bool> Init(string lang, string absoluteDataPath, OcrEngineMode? mode = null);
+        /// <summary>
         /// Recognise image.
         /// </summary>
         Task<bool> SetImage (string path);

--- a/UnitTest/Tesseract.iOS.Test/TesseractApiInitTest.cs
+++ b/UnitTest/Tesseract.iOS.Test/TesseractApiInitTest.cs
@@ -63,6 +63,14 @@ namespace Tesseract.iOS.Test
             var result = await _api.Init (null);
             Assert.IsFalse (result);
         }
+
+        // Failing test due to G8Tesseract constructor issue.
+        [Test]
+        public async void InitWithAbsoluteDataPath ()
+        {
+            var result = await _api.Init (null, "/Volumes/MacintoshHD/Users/mvassilev/temp/Resources/", OcrEngineMode.TesseractCubeCombined);
+            Assert.IsTrue (result);
+        }
     }
 }
 


### PR DESCRIPTION
Hi,
We have a problem with Tesseract not able to init by using the specified constructor - G8Tesseract (string language, NSDictionary configDictionary, NSObject[] configFileNames, string absoluteDataPath, G8OCREngineMode engineMode, bool copyFilesFromResources).

I have provided a failing test case using the mentioned constructor.
Could you please point me what am I doing wrong or how to debug this issue?

